### PR TITLE
Improve UI explanations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ The app sends your question to an AI (Groq) and tells it to only answer YES or N
 4. Run `npm run dev`
 5. Ask away!
 
+## Usage
+
+1. Type a yes/no question in the input box (for example, "Is water wet?")
+2. Press **Submit** to send the question to the AI
+3. The box labelled **YES** or **NO** will glow to show the AI's answer
+4. Any connection issues will be reported below the input field
+
 ## Built With
 
 - Next.js

--- a/components/ai-decision-visualizer.tsx
+++ b/components/ai-decision-visualizer.tsx
@@ -71,6 +71,16 @@ export default function AIDecisionVisualizer() {
           AI Decision Visualizer
         </motion.h1>
 
+        <motion.p
+          className="text-center text-sm md:text-base text-white/80 max-w-lg"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.4, duration: 0.8 }}
+        >
+          Type a yes or no question below and watch the corresponding box glow
+          green for YES or red for NO.
+        </motion.p>
+
         <InputContainer onSubmit={handleSubmit} isLoading={loading} />
 
         {response && response.includes("Error") && (
@@ -92,7 +102,10 @@ export default function AIDecisionVisualizer() {
             transition={{ delay: 1.2, duration: 0.8 }}
             className="text-xs text-center text-white/60 max-w-md px-4"
           >
-            This app demonstrates how to visualize AI decision logic using React and Framer Motion.
+            This demo uses Groq's language model to answer with
+            <span className="font-semibold"> YES </span> or
+            <span className="font-semibold"> NO</span>. The glowing boxes
+            highlight the AI's choice in real time.
           </motion.div>
 
           <Footer />

--- a/components/input-container.tsx
+++ b/components/input-container.tsx
@@ -34,7 +34,8 @@ export default function InputContainer({ onSubmit, isLoading }: InputContainerPr
             type="text"
             value={message}
             onChange={(e) => setMessage(e.target.value)}
-            placeholder="Ask a yes/no question..."
+            placeholder="Ask a yes/no question, e.g. \"Is the sky blue?\""
+            aria-label="yes or no question"
             className="flex-1 bg-black/30 text-white font-mono px-4 py-3 rounded-lg outline-none border border-transparent focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/20 transition-all"
             whileFocus={{ boxShadow: "0 0 20px rgba(59, 130, 246, 0.6)" }}
             disabled={isLoading}


### PR DESCRIPTION
## Summary
- add detailed usage section to README
- guide users in app with an intro paragraph
- show instructions and accessible placeholder

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: dependency conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_686947dfbebc8323802fc36b672bfa6b